### PR TITLE
Fix browsable API access

### DIFF
--- a/.idea/ultimanager-web.iml
+++ b/.idea/ultimanager-web.iml
@@ -2,7 +2,7 @@
 <module type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="Python" name="Python">
-      <configuration sdkName="Pipenv (ultimanager-web)" />
+      <configuration sdkName="" />
     </facet>
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
@@ -12,7 +12,6 @@
     </content>
     <orderEntry type="jdk" jdkName="Pipenv (ultimanager-api)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Pipenv (ultimanager-api) interpreter library" level="application" />
   </component>
   <component name="PackageRequirementsSettings">
     <option name="requirementsPath" value="" />

--- a/ultimanager/functional_tests/test_browseable_api.py
+++ b/ultimanager/functional_tests/test_browseable_api.py
@@ -1,0 +1,10 @@
+def test_view_browsable_api(client):
+    """
+    Test viewing the browsable API.
+
+    Regression test for #22
+    """
+    # Arbitrary endpoint. Important thing is we access an endpoint of
+    # the browsable API and force an HTML response so that template
+    # rendering is used.
+    client.get("/accounts/users/", HTTP_ACCEPT="text/html")

--- a/ultimanager/ultimanager/settings.py
+++ b/ultimanager/ultimanager/settings.py
@@ -130,6 +130,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     # Third-Party Apps
     "email_auth",
+    "rest_framework",
     # Custom Apps
     "account",
     "account.api",


### PR DESCRIPTION
Added `rest_framework` to `settings.INSTALLED_APPS` so that the templates from the app are accessible.

Fixes #22