### PR TITLE
Add endpoint to verify an email address

### DIFF
--- a/ultimanager/account/api/serializers.py
+++ b/ultimanager/account/api/serializers.py
@@ -1,8 +1,50 @@
 from django.contrib.auth import password_validation
-from email_auth.models import EmailAddress
+from django.utils.translation import ugettext_lazy as _
+from email_auth.models import EmailAddress, TOKEN_LENGTH, EmailVerification
 from rest_framework import serializers
 
 from account import models
+
+
+class EmailVerificationSerializer(serializers.Serializer):
+    """
+    Serializer for verifying email addresses.
+    """
+
+    token = serializers.CharField(max_length=TOKEN_LENGTH, write_only=True)
+
+    _verification: EmailVerification = None
+
+    def save(self, **kwargs):
+        """
+        Mark the email address associated with the token as verified and
+        delete the verification token.
+        """
+        self._verification.verify()
+
+    def validate_token(self, token):
+        """
+        Validate the provided token.
+
+        Args:
+            token:
+                The token to validate.
+
+        Returns:
+            The provided token if it exists in the database.
+
+        Raises:
+            serializers.ValidationError:
+                If the token is invalid.
+        """
+        try:
+            self._verification = EmailVerification.objects.get(token=token)
+        except EmailVerification.DoesNotExist:
+            raise serializers.ValidationError(
+                _("The provided verification token is invalid.")
+            )
+
+        return token
 
 
 class UserCreationSerializer(serializers.Serializer):

--- a/ultimanager/account/api/test/serializers/test_email_verification_serializer.py
+++ b/ultimanager/account/api/test/serializers/test_email_verification_serializer.py
@@ -1,0 +1,58 @@
+from unittest import mock
+
+import pytest
+from email_auth.models import EmailVerification
+from rest_framework.exceptions import ValidationError
+
+from account.api import serializers
+
+
+@mock.patch("email_auth.models.EmailVerification.verify")
+def test_save_valid_data(mock_verify, mock_email_verification_qs):
+    """
+    Saving a serializer with a valid token should mark the email address
+    associated with the token as verified and delete the token.
+    """
+    verification = EmailVerification()
+    mock_email_verification_qs.get.return_value = verification
+
+    data = {"token": verification.token}
+    serializer = serializers.EmailVerificationSerializer(data=data)
+
+    assert serializer.is_valid()
+    serializer.save()
+
+    assert serializer.data == {}
+    assert mock_verify.call_count == 1
+    assert mock_email_verification_qs.get.call_args[1] == {
+        "token": verification.token
+    }
+
+
+def test_validate_valid_token(mock_email_verification_qs):
+    """
+    If the token is valid, it should be returned.
+    """
+    verification = EmailVerification()
+    mock_email_verification_qs.get.return_value = verification
+    serializer = serializers.EmailVerificationSerializer()
+
+    token = serializer.validate_token(verification.token)
+
+    assert token == verification.token
+    assert mock_email_verification_qs.get.call_args[1] == {
+        "token": verification.token
+    }
+
+
+def test_validate_invalid_token(mock_email_verification_qs):
+    """
+    If the provided token does not match any tokens in the database, a
+    ValidationError should be raised.
+    """
+    token = "invalid"
+    mock_email_verification_qs.get.side_effect = EmailVerification.DoesNotExist
+    serializer = serializers.EmailVerificationSerializer()
+
+    with pytest.raises(ValidationError):
+        serializer.validate_token(token)

--- a/ultimanager/account/api/test/views/test_email_verification_view.py
+++ b/ultimanager/account/api/test/views/test_email_verification_view.py
@@ -1,0 +1,11 @@
+from account.api import views, serializers
+
+
+def test_get_serializer_class():
+    """
+    Test the serializer class used by the view.
+    """
+    view = views.EmailVerificationView()
+    expected = serializers.EmailVerificationSerializer
+
+    assert view.get_serializer_class() == expected

--- a/ultimanager/account/api/urls.py
+++ b/ultimanager/account/api/urls.py
@@ -7,5 +7,10 @@ app_name = "account:api"
 
 
 urlpatterns = [
-    path("users/", views.UserCreateView.as_view(), name="user-create")
+    path(
+        "email-verifications/",
+        views.EmailVerificationView.as_view(),
+        name="email-verification-create",
+    ),
+    path("users/", views.UserCreateView.as_view(), name="user-create"),
 ]

--- a/ultimanager/account/api/views.py
+++ b/ultimanager/account/api/views.py
@@ -3,6 +3,15 @@ from rest_framework import generics
 from account.api import serializers
 
 
+class EmailVerificationView(generics.CreateAPIView):
+    """
+    post:
+    Verify an email address using a verification token.
+    """
+
+    serializer_class = serializers.EmailVerificationSerializer
+
+
 class UserCreateView(generics.CreateAPIView):
     """
     post:

--- a/ultimanager/account/conftest.py
+++ b/ultimanager/account/conftest.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from email_auth.models import EmailAddress
+from email_auth.models import EmailAddress, EmailVerification
 
 
 @pytest.fixture
@@ -10,4 +10,15 @@ def mock_email_address_qs():
     mock_qs.all.return_value = mock_qs
 
     with mock.patch("email_auth.models.EmailAddress.objects", new=mock_qs):
+        yield mock_qs
+
+
+@pytest.fixture
+def mock_email_verification_qs():
+    mock_qs = mock.Mock(spec=EmailVerification.objects)
+    mock_qs.all.return_value = mock_qs
+
+    with mock.patch(
+        "email_auth.models.EmailVerification.objects", new=mock_qs
+    ):
         yield mock_qs

--- a/ultimanager/functional_tests/accounts/emails/test_email_verification.py
+++ b/ultimanager/functional_tests/accounts/emails/test_email_verification.py
@@ -1,0 +1,24 @@
+import requests
+from django.contrib.auth import get_user_model
+from email_auth.models import EmailVerification, EmailAddress
+from rest_framework import status
+
+
+def test_verify_email(live_server):
+    """
+    Sending a ``POST`` request to the verification endpoint with a valid
+    verification token should verify the associated email address.
+    """
+    user = get_user_model().objects.create_user(name="Test User")
+    email = EmailAddress.objects.create(address="test@example.com", user=user)
+    verification = EmailVerification.objects.create(email=email)
+
+    url = f"{live_server}/accounts/email-verifications/"
+    response = requests.post(url, {"token": verification.token})
+
+    assert response.status_code == status.HTTP_201_CREATED
+
+    email.refresh_from_db()
+
+    assert email.is_verified
+    assert not email.verifications.exists()


### PR DESCRIPTION
Sending a `POST` request to `/accounts/email-verifications/` with the a verification token in the request body will verify the email address associated with the provided token.

Closes #24