### PR TITLE
Add password reset functionality

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,6 +7,10 @@
       </value>
     </option>
     <option name="SOFT_MARGINS" value="72,79" />
+    <Python>
+      <option name="OPTIMIZE_IMPORTS_SORT_NAMES_IN_FROM_IMPORTS" value="true" />
+      <option name="OPTIMIZE_IMPORTS_JOIN_FROM_IMPORTS_WITH_SAME_SOURCE" value="true" />
+    </Python>
     <codeStyleSettings language="CSS">
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ sphinx-autobuild = "*"
 sphinx-rtd-theme = "*"
 sphinxcontrib-napoleon = "*"
 requests = "*"
+ipython = "*"
 
 [packages]
 django = "<2.3,>=2.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "54f0baf95ec3cfed3038fdb9b1ce5d46bc06d8f0f9b68451a49289ed1a512172"
+            "sha256": "a113cd751132f1300e6a7d7cb3811f55ae6c2444d585d1387f642a3e72f2a1ca"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,18 +18,18 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:0e4d047feb4d7d701e9b2107f10bb8d674952243385cd35d0b413a273c299751",
-                "sha256:67f957389cf56fb4c24c1093c6d58baebe6cf18139f6dca0f8a177239b0a4f8c"
+                "sha256:012dee0d170d9ee637831a2766c3d5a9cddbe3b18bf688b4c348ec591411bd21",
+                "sha256:2fd733957e83546547cede51ebf7356a14eeb369293e1e918e7eabcc7cf30e2c"
             ],
             "index": "pypi",
-            "version": "==1.9.232"
+            "version": "==1.9.233"
         },
         "botocore": {
             "hashes": [
-                "sha256:724d2349198c6f15f3cee0c0e4d33ecf4435e6d0db311bb79a3a28f6cf5a4090",
-                "sha256:a57a8fd0145c68e31bb4baab549b27a12f6695068c8dd5f2901d8dc06572dbeb"
+                "sha256:9b0bf5614a0e6a29838dc1bc3d38405c57ec6dc3e25709776f9d2d7f7e84b0e0",
+                "sha256:9b93ca5743e9209daaece3e682626d8370f04c9693760c7c1e7fd95b746e45ff"
             ],
-            "version": "==1.12.232"
+            "version": "==1.12.233"
         },
         "certifi": {
             "hashes": [
@@ -188,11 +188,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:1c5da96f77307d0afc7811f3adc736c363c52388700e449c6a5310be44c82376",
-                "sha256:61ac4fe28f8c67f0adf8740da77c84bf787034f9d32c60a77adac4d899a48a50"
+                "sha256:2529ab6f93914d01bcd80b1b16c15a025902350ab19af2033aa5ff797c1600ad",
+                "sha256:ab16b539c40cc18e3dcfec99d0d3fff16337a050eaf79d4503ef2b73af9a7d9e"
             ],
             "index": "pypi",
-            "version": "==0.12.1"
+            "version": "==0.12.2"
         },
         "six": {
             "hashes": [
@@ -267,6 +267,13 @@
             ],
             "version": "==2.7.0"
         },
+        "backcall": {
+            "hashes": [
+                "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
+                "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
+            ],
+            "version": "==0.1.0"
+        },
         "black": {
             "hashes": [
                 "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf",
@@ -313,36 +320,43 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:108efa19b676e62590a7a13084098e35183479c0d9608131c20b0921c5a72dc0",
-                "sha256:16fe3ef881eff27bab287f91dadb4ff0ce4388b9e928d84cbf148a83cc70b3a1",
-                "sha256:1d0bbc11421827d1100da82ac8dc929532b97ad464038475a0f6505cbf83d6ea",
-                "sha256:23a8ca5b3c9673f775cc151e85a737f1a967df2ec02b09e8c5a3b606ff2050bf",
-                "sha256:24b890e51455276762b55cb06fa1c922066e8fc18d1deb1a6399b4d24dfa8ea2",
-                "sha256:2f0041757ca4801f3c6a74d1660862fdb18a25aea302dd0ce9b067ddbb06b667",
-                "sha256:3169aba03baddfccdab7cc04cf0878dbf76fc06d300bc35639129a6b794d6484",
-                "sha256:364fb1bf0f999af2e7f4b1a1e614b2af8c3e0017d11af716aad25f911b7cd0c7",
-                "sha256:5256856d23f3e45959e7e3a8f9d4cbad3d1613e5660cb8117cd1417798efc395",
-                "sha256:5b26daa1e1a1147455bf62cd682e504e68f1d1e04235374d50a5248a3c792b1c",
-                "sha256:60247c8f0c756732e2cfe21f03e6847b923b9a9eaff61f04dc64d3047ec1b669",
-                "sha256:6463d51507308eb3973340d903537f17ece2ee1e6513aa0c27548fc3a09b0471",
-                "sha256:64cbadf7a884b299794238bc4391752130e74f71e919993b50c1c431786ef2a2",
-                "sha256:6de85748ea39ce819ad6d90e660da43964457a1f5cd25262e962a7c7c87945b3",
-                "sha256:6f95b4794bd84f64aeca25087d8e3abc416aad76842afcac34fa6c3a6f61c62e",
-                "sha256:778fa184aa3079fa3cbd240e2f5b36771c3382db26bc7bf78aea9d06212c6c66",
-                "sha256:790a9c5e2dbdf6c41eec9776ed663e99bd36c1604e3bf2e8ae3b123181bfee9f",
-                "sha256:7d97c1aec0b68b4ea5e3c9edb9fc3f951e8a52360f4bad3aacab9a77defe5b17",
-                "sha256:93cefddcc0b541d3c52981a232947bf085a38092b0812317f1adb56f02869bcb",
-                "sha256:95e49867ac616ec63ecd69ea005e65e4b896a48b8db7f9f3ad69f37be29324b7",
-                "sha256:aca423563eafba66a7c15125391b267befd1e45238de5e1a119ae1fb4ea83b5c",
-                "sha256:baef7c35e7fce738d9637e9c7a6aa79cb79085e4de49c2ec517ce19239a660f6",
-                "sha256:c10ccf0797ffce85e93a40aff3a96a3adb63c734f95b59384a7c9522ed25c9e2",
-                "sha256:ca39704a05bba1886c384a4d7944fda72c53fe5e61979cd933d22084678ad4c1",
-                "sha256:f6e96d5eee578187f5b7e9266bf646b73de29e2dd7adca8bd83e383680ce1f4c",
-                "sha256:fc6524511fa664cb4e91401229eedd0dad4ba6ded9c4423fee2f698d78908d9c",
-                "sha256:fdf2e7e5f074495ad6ea796ca0d245aa6a8b9e4c546ffbf8d30aaaee6601af0f"
+                "sha256:094378c3a35594335a840ea04d473c019e6d4fe10e343cd0d7fb5e87f8b7e926",
+                "sha256:10216222f3e4139910b6230d0ca0fe9d10ee98837eb83d29525722d628729d20",
+                "sha256:147478e21cba12c63b3454df5a2fb77b44df630428cffa3a36a6813e38157eab",
+                "sha256:230ce08965190c0f69196be34a07a795981b2b02b21419c2e1918a882b3eeab0",
+                "sha256:2469621d680a4c71cdbd3ea4dbed9d199bba93f21d2be1c107ded907b2db41a8",
+                "sha256:26526174d11fb2163832628d943edd452e07528b0ecc0c83c88256a59a32287c",
+                "sha256:2690bf0835f34ef3451860b02471e9560e4b3caf7413abeaa7544af72eb6d9ed",
+                "sha256:2b6f2d9a60413e75651cebe33c3f2f66d61209db44e8b9cf6d8d66fb0cb01fda",
+                "sha256:3ce91c6b92160ecefedf95a8c61fbf4fb36b0addef1a40c654acf1ad390653d0",
+                "sha256:43d16d7e9e9eaace3d9f1828b617b1be248f90d031a4b2dc1b6e1c88f1602dcf",
+                "sha256:52b6455da5f547cad72fd5cfc57a16678573fda6c695d257b5c266a44dbbd172",
+                "sha256:533f3036c8f58e6381fcca3306fe988740638c62c7fc86b7fae9c74b85ac3cdc",
+                "sha256:62d2abe5c733394058cb381d088bcab64a18da3ce9dc9a8ef2a18e122cbe47f1",
+                "sha256:72c34f99164679e44a5cbf19bf1a13be4e715c680816302b6ceca49b979fde91",
+                "sha256:81fc07feed4e40a7c0bdd266efa65e5afc83b5e0f1063007acc6759a957322a1",
+                "sha256:82093e673182c761ce54dfab17f026a06be3c011fee9b653855b9a2649f20232",
+                "sha256:87947fef728f72860407c446fd9b4a0f98e39e91ad7ae80803c02a85738e63ef",
+                "sha256:8b18c5a5a6b35b6311d2c356782ce3c7bacf6d987d9dc479178577391bf1c7dd",
+                "sha256:90e1850e993aa6b81bafaf672c8e508eaa17fbb5eb23aba93f7f4df822f3bd29",
+                "sha256:99f71e365bcb03a8debe1a75061329c9e45379f244a229442319d64c53c4e844",
+                "sha256:9b2c559104a90bf0043d6ef262ca205326d1fe6ec572dcf59e34be9289432793",
+                "sha256:ad22b073d92ea65b063e612154c72d6367dec3dd47ed33c02e3ab339eabe7bf3",
+                "sha256:bc3648da235fee2113a8cb80154d9fff4e2689d2d4a11ad35c1ecae23454b539",
+                "sha256:d0e2478bde68c5d853bcd306b5aae8fbe80417e87957a21fa6ee71edb90639f2",
+                "sha256:d3e6912d2370925222d2bfb3bd2ba02e9698b8da89cf7192ddf80cbb9f2455ee",
+                "sha256:d4fa98e3e15863568ea89eaec5e0866ca763980bdc56098dd9316865c111a28e",
+                "sha256:ee924a23457b373241ff39d21570360afd8ccb58520eb1e8e18eb00827b73e2d"
             ],
             "index": "pypi",
-            "version": "==5.0a6"
+            "version": "==5.0a7"
+        },
+        "decorator": {
+            "hashes": [
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+            ],
+            "version": "==4.4.0"
         },
         "docutils": {
             "hashes": [
@@ -395,6 +409,28 @@
             ],
             "markers": "python_version < '3.8'",
             "version": "==0.23"
+        },
+        "ipython": {
+            "hashes": [
+                "sha256:c4ab005921641e40a68e405e286e7a1fcc464497e14d81b6914b4fd95e5dee9b",
+                "sha256:dd76831f065f17bddd7eaa5c781f5ea32de5ef217592cf019e34043b56895aa1"
+            ],
+            "index": "pypi",
+            "version": "==7.8.0"
+        },
+        "ipython-genutils": {
+            "hashes": [
+                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
+                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
+            ],
+            "version": "==0.2.0"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:786b6c3d80e2f06fd77162a07fed81b8baa22dde5d62896a790a331d6ac21a27",
+                "sha256:ba859c74fa3c966a22f2aeebe1b74ee27e2a462f56d3f5f7ca4a59af61bfe42e"
+            ],
+            "version": "==0.15.1"
         },
         "jinja2": {
             "hashes": [
@@ -470,11 +506,33 @@
             ],
             "version": "==19.2"
         },
+        "parso": {
+            "hashes": [
+                "sha256:63854233e1fadb5da97f2744b6b24346d2750b85965e7e399bec1620232797dc",
+                "sha256:666b0ee4a7a1220f65d367617f2cd3ffddff3e205f3f16a0284df30e774c2a9c"
+            ],
+            "version": "==0.5.1"
+        },
         "pathtools": {
             "hashes": [
                 "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"
             ],
             "version": "==0.1.2"
+        },
+        "pexpect": {
+            "hashes": [
+                "sha256:2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1",
+                "sha256:9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"
+            ],
+            "markers": "sys_platform != 'win32'",
+            "version": "==4.7.0"
+        },
+        "pickleshare": {
+            "hashes": [
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
+            ],
+            "version": "==0.7.5"
         },
         "pluggy": {
             "hashes": [
@@ -503,6 +561,21 @@
             ],
             "index": "pypi",
             "version": "==1.18.3"
+        },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:11adf3389a996a6d45cc277580d0d53e8a5afd281d0c9ec71b28e6f121463780",
+                "sha256:2519ad1d8038fd5fc8e770362237ad0364d16a7650fb5724af6997ed5515e3c1",
+                "sha256:977c6583ae813a37dc1c2e1b715892461fcbdaa57f6fc62f33a528c4886c8f55"
+            ],
+            "version": "==2.0.9"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
+            ],
+            "version": "==0.6.0"
         },
         "py": {
             "hashes": [
@@ -541,11 +614,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:95d13143cc14174ca1a01ec68e84d76ba5d9d493ac02716fd9706c949a505210",
-                "sha256:b78fe2881323bd44fd9bd76e5317173d4316577e7b1cddebae9136a4495ec865"
+                "sha256:813b99704b22c7d377bbd756ebe56c35252bb710937b46f207100e843440b3c2",
+                "sha256:cc6620b96bc667a0c8d4fa592a8c9c94178a1bd6cc799dbb057dfd9286d31a31"
             ],
             "index": "pypi",
-            "version": "==5.1.2"
+            "version": "==5.1.3"
         },
         "pytest-django": {
             "hashes": [
@@ -693,6 +766,13 @@
                 "sha256:c9399267c926a4e7c418baa5cbe91c7d1cf362d505a1ef898fde44a07c9dd8a5"
             ],
             "version": "==6.0.3"
+        },
+        "traitlets": {
+            "hashes": [
+                "sha256:9c4bd2d267b7153df9152698efb1050a5d84982d3384a37b2c1f7723ba3e7835",
+                "sha256:c6cb5e6f57c5a9bdaa40fa71ce7b4af30298fbab9ece9815b5d995ab6217c7d9"
+            ],
+            "version": "==4.3.2"
         },
         "urllib3": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -70,11 +70,11 @@
         },
         "django-simple-email-auth": {
             "hashes": [
-                "sha256:79e32611d40a73fc8aae9ed5b57f9a448d4903a261d0fcb41ebbde51f04460f4",
-                "sha256:9547da97b0b5162170ed181685f5c74123e4c9f2036099dbe0626bccdb08342c"
+                "sha256:c3dd70781e302d7d932072c439a6c1629baeb0bfd9d1dad44115ea66366c41ad",
+                "sha256:f2f2dbe52629b7dd6207f4f50dd38de3d6eb8438acce6ac8a3e7cf1324f2b804"
             ],
             "index": "pypi",
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "django-storages": {
             "hashes": [

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,18 +6,20 @@ aspy.yaml==1.3.0
 atomicwrites==1.3.0
 attrs==19.1.0
 babel==2.7.0
+backcall==0.1.0
 black==19.3b0
-boto3==1.9.232
-botocore==1.12.232
+boto3==1.9.233
+botocore==1.12.233
 certifi==2019.9.11
 cfgv==2.0.1
 chardet==3.0.4
 click==7.0
 codecov==2.0.15
-coverage==5.0a6
+coverage==5.0a7
+decorator==4.4.0
 django-cors-headers==3.1.0
 django-email-utils==1.0.0
-django-simple-email-auth==0.3.0
+django-simple-email-auth==0.3.1
 django-storages==1.7.2
 django==2.2.5
 djangorestframework==3.10.3
@@ -29,6 +31,9 @@ identify==1.4.7
 idna==2.8
 imagesize==1.1.0
 importlib-metadata==0.23 ; python_version < '3.8'
+ipython-genutils==0.2.0
+ipython==7.8.0
+jedi==0.15.1
 jinja2==2.10.1
 jmespath==0.9.4
 livereload==2.6.1
@@ -37,25 +42,30 @@ mccabe==0.6.1
 more-itertools==7.2.0
 nodeenv==1.3.3
 packaging==19.2
+parso==0.5.1
 pathtools==0.1.2
+pexpect==4.7.0 ; sys_platform != 'win32'
+pickleshare==0.7.5
 pluggy==0.13.0
 pockets==0.7.2
 port-for==0.3.1
 pre-commit==1.18.3
+prompt-toolkit==2.0.9
 psycopg2-binary==2.8.3
+ptyprocess==0.6.0
 py==1.8.0
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pygments==2.4.2
 pyparsing==2.4.2
 pytest-django==3.5.1
-pytest==5.1.2
+pytest==5.1.3
 python-dateutil==2.8.0 ; python_version >= '2.7'
 pytz==2019.2
 pyyaml==5.1.2
 requests==2.22.0
 s3transfer==0.2.1
-sentry-sdk==0.12.1
+sentry-sdk==0.12.2
 six==1.12.0
 snowballstemmer==1.9.1
 sphinx-autobuild==0.7.1
@@ -71,6 +81,7 @@ sphinxcontrib-serializinghtml==1.1.3
 sqlparse==0.3.0
 toml==0.10.0
 tornado==6.0.3
+traitlets==4.3.2
 urllib3==1.25.5 ; python_version >= '3.4'
 virtualenv==16.7.5
 watchdog==0.9.0

--- a/ultimanager/account/api/test/serializers/test_password_reset_request_serializer.py
+++ b/ultimanager/account/api/test/serializers/test_password_reset_request_serializer.py
@@ -3,17 +3,7 @@ from unittest import mock
 from email_auth.models import EmailAddress
 
 from account.api import serializers
-
-
-def return_for_conditions(obj, raise_ex=False, **kwargs):
-    def handler(**inner_kwargs):
-        if kwargs.items() <= inner_kwargs.items():
-            if raise_ex:
-                raise obj
-
-            return obj
-
-    return handler
+from account.api.test_utils import return_for_conditions
 
 
 def test_save_unregistered_email(mock_email_address_qs):

--- a/ultimanager/account/api/test/serializers/test_password_reset_request_serializer.py
+++ b/ultimanager/account/api/test/serializers/test_password_reset_request_serializer.py
@@ -1,0 +1,80 @@
+from unittest import mock
+
+from email_auth.models import EmailAddress
+
+from account.api import serializers
+
+
+def return_for_conditions(obj, raise_ex=False, **kwargs):
+    def handler(**inner_kwargs):
+        if kwargs.items() <= inner_kwargs.items():
+            if raise_ex:
+                raise obj
+
+            return obj
+
+    return handler
+
+
+def test_save_unregistered_email(mock_email_address_qs):
+    """
+    If the provided email address doesn't exist in the system, saving
+    should do nothing.
+    """
+    address = "test@example.com"
+    mock_email_address_qs.get.side_effect = return_for_conditions(
+        EmailAddress.DoesNotExist, address__iexact=address, raise_ex=True
+    )
+
+    data = {"email": address}
+    serializer = serializers.PasswordResetRequestSerializer(data=data)
+
+    assert serializer.is_valid()
+    result = serializer.save()
+
+    assert result is None
+    assert serializer.data == data
+
+
+def test_save_unverified_email(mock_email_address_qs):
+    """
+    If the provided email address has not been verified yet, saving the
+    serializer should do nothing.
+    """
+    address = "test@example.com"
+    mock_email_address_qs.get.side_effect = return_for_conditions(
+        EmailAddress.DoesNotExist,
+        address__iexact=address,
+        is_verified=True,
+        raise_ex=True,
+    )
+
+    data = {"email": address}
+    serializer = serializers.PasswordResetRequestSerializer(data=data)
+
+    assert serializer.is_valid()
+    result = serializer.save()
+
+    assert result is None
+    assert serializer.data == data
+
+
+@mock.patch("email_auth.models.PasswordReset.send_email")
+def test_save_verified_email(_, mock_email_address_qs):
+    """
+    If a verified email is provided, saving the serializer should send
+    a new password reset token to the provided address.
+    """
+    email = EmailAddress(address="test@example.com")
+    mock_email_address_qs.get.side_effect = return_for_conditions(
+        email, address__iexact=True, is_verified=True
+    )
+
+    data = {"email": email.address}
+    serializer = serializers.PasswordResetRequestSerializer(data=data)
+
+    assert serializer.is_valid()
+    result = serializer.save()
+
+    assert serializer.data == data
+    assert result.send_email.call_count == 1

--- a/ultimanager/account/api/test/serializers/test_password_reset_serializer.py
+++ b/ultimanager/account/api/test/serializers/test_password_reset_serializer.py
@@ -1,0 +1,81 @@
+from unittest import mock
+
+
+# Since the serializer uses Django's built in password validators, we
+# need a password that will pass them.
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from email_auth.models import EmailAddress, PasswordReset
+
+from account.api import test_utils, serializers
+
+NEW_PASSWORD = "MySup3rSecurePassword"
+
+
+@mock.patch("account.models.User.save", autospec=True)
+@mock.patch("email_auth.models.PasswordReset.delete", autospec=True)
+def test_save_valid_token(_, __, mock_password_reset_qs):
+    """
+    Saving the serializer with a valid token should reset the password
+    of the user associated with the reset.
+    """
+    user = get_user_model()(name="Test User")
+    email = EmailAddress(user=user)
+    reset = PasswordReset(email=email)
+    mock_password_reset_qs.get.side_effect = test_utils.return_for_conditions(
+        reset, token=reset.token
+    )
+
+    data = {"password": NEW_PASSWORD, "token": reset.token}
+    serializer = serializers.PasswordResetSerializer(data=data)
+
+    assert serializer.is_valid()
+    serializer.save()
+
+    assert serializer.data == {}
+    assert user.check_password(NEW_PASSWORD)
+    assert user.save.call_count == 1
+    assert reset.delete.call_count == 1
+
+
+@mock.patch(
+    "account.api.serializers.password_validation.validate_password",
+    autospec=True,
+    side_effect=ValidationError("Invalid password"),
+)
+def test_validate(mock_validate_password, mock_password_reset_qs):
+    """
+    If the provided token is valid, the provided password should be run
+    through Django's password validation system.
+    """
+    user = get_user_model()()
+    email = EmailAddress(user=user)
+    reset = PasswordReset(email=email)
+    mock_password_reset_qs.get.side_effect = test_utils.return_for_conditions(
+        reset, token=reset.token
+    )
+
+    data = {"password": NEW_PASSWORD, "token": reset.token}
+    serializer = serializers.PasswordResetSerializer(data=data)
+
+    assert not serializer.is_valid()
+    assert set(serializer.errors.keys()) == {"password"}
+    assert mock_validate_password.call_args[0][0] == NEW_PASSWORD
+    assert mock_validate_password.call_args[1] == {"user": user}
+
+
+def test_validate_invalid_token(mock_password_reset_qs):
+    """
+    If the provided token is not valid, a validation error should be
+    raised.
+    """
+    token = "foo"
+    mock_password_reset_qs.get.side_effect = test_utils.return_for_conditions(
+        PasswordReset.DoesNotExist, raise_ex=True, token=token
+    )
+
+    data = {"password": NEW_PASSWORD, "token": token}
+    serializer = serializers.PasswordResetSerializer(data=data)
+
+    assert not serializer.is_valid()
+    assert set(serializer.errors.keys()) == {"token"}

--- a/ultimanager/account/api/test/views/test_password_reset_request_view.py
+++ b/ultimanager/account/api/test/views/test_password_reset_request_view.py
@@ -1,0 +1,11 @@
+from account.api import views, serializers
+
+
+def test_get_serializer_class():
+    """
+    Test the serializer class used by the view.
+    """
+    view = views.PasswordResetRequestView()
+    expected = serializers.PasswordResetRequestSerializer
+
+    assert view.get_serializer_class() == expected

--- a/ultimanager/account/api/test/views/test_password_reset_view.py
+++ b/ultimanager/account/api/test/views/test_password_reset_view.py
@@ -1,0 +1,11 @@
+from account.api import views, serializers
+
+
+def test_get_serializer_class():
+    """
+    Test the serializer class used by the view.
+    """
+    view = views.PasswordResetView()
+    expected = serializers.PasswordResetSerializer
+
+    assert view.get_serializer_class() == expected

--- a/ultimanager/account/api/test_utils.py
+++ b/ultimanager/account/api/test_utils.py
@@ -1,0 +1,30 @@
+def return_for_conditions(obj, raise_ex=False, **kwargs):
+    """
+    Get a function that returns/raises an object and is suitable as a
+    ``side_effect`` for a mock object.
+
+    Args:
+        obj:
+            The object to return/raise.
+        raise_ex:
+            A boolean indicating if the object should be raised instead
+            of returned.
+        **kwargs:
+            The keyword arguments that must be provided to the function
+            being mocked in order for the provided object to be returned
+            or raised. As long as the mocked function is called with at
+            least the arguments provided to this function, the handler
+            is triggered.
+
+    Returns:
+        A function usable as the side effect of a mocked object.
+    """
+
+    def handler(**inner_kwargs):
+        if kwargs.items() <= inner_kwargs.items():
+            if raise_ex:
+                raise obj
+
+            return obj
+
+    return handler

--- a/ultimanager/account/api/urls.py
+++ b/ultimanager/account/api/urls.py
@@ -22,5 +22,10 @@ urlpatterns = [
         views.PasswordResetRequestView.as_view(),
         name="password-reset-request-create",
     ),
+    path(
+        "password-resets/",
+        views.PasswordResetView.as_view(),
+        name="password-reset-create",
+    ),
     path("users/", views.UserCreateView.as_view(), name="user-create"),
 ]

--- a/ultimanager/account/api/urls.py
+++ b/ultimanager/account/api/urls.py
@@ -17,5 +17,10 @@ urlpatterns = [
         views.EmailVerificationView.as_view(),
         name="email-verification-create",
     ),
+    path(
+        "password-reset-requests/",
+        views.PasswordResetRequestView.as_view(),
+        name="password-reset-request-create",
+    ),
     path("users/", views.UserCreateView.as_view(), name="user-create"),
 ]

--- a/ultimanager/account/api/views.py
+++ b/ultimanager/account/api/views.py
@@ -26,6 +26,19 @@ class EmailVerificationView(generics.CreateAPIView):
     serializer_class = serializers.EmailVerificationSerializer
 
 
+class PasswordResetRequestView(generics.CreateAPIView):
+    """
+    post:
+    Send a token to the provided email address that the user can use to
+    reset their password.
+
+    If the provided email address has not been verified or has not been
+    registered with our system, no email is sent.
+    """
+
+    serializer_class = serializers.PasswordResetRequestSerializer
+
+
 class UserCreateView(generics.CreateAPIView):
     """
     post:

--- a/ultimanager/account/api/views.py
+++ b/ultimanager/account/api/views.py
@@ -39,6 +39,16 @@ class PasswordResetRequestView(generics.CreateAPIView):
     serializer_class = serializers.PasswordResetRequestSerializer
 
 
+class PasswordResetView(generics.CreateAPIView):
+    """
+    post:
+    Reset the user's password using a valid password reset token to
+    authorize the operation.
+    """
+
+    serializer_class = serializers.PasswordResetSerializer
+
+
 class UserCreateView(generics.CreateAPIView):
     """
     post:

--- a/ultimanager/account/conftest.py
+++ b/ultimanager/account/conftest.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 import pytest
-from email_auth.models import EmailAddress, EmailVerification
+from email_auth.models import EmailAddress, EmailVerification, PasswordReset
 
 
 @pytest.fixture
@@ -21,4 +21,13 @@ def mock_email_verification_qs():
     with mock.patch(
         "email_auth.models.EmailVerification.objects", new=mock_qs
     ):
+        yield mock_qs
+
+
+@pytest.fixture
+def mock_password_reset_qs():
+    mock_qs = mock.Mock(spec=PasswordReset.objects)
+    mock_qs.all.return_value = mock_qs
+
+    with mock.patch("email_auth.models.PasswordReset.objects", new=mock_qs):
         yield mock_qs

--- a/ultimanager/functional_tests/accounts/passwords/test_password_resets.py
+++ b/ultimanager/functional_tests/accounts/passwords/test_password_resets.py
@@ -4,7 +4,7 @@ from email_auth.models import EmailAddress, PasswordReset
 from rest_framework import status
 
 
-def test_password_reset_unregistered_email(live_server, mailoutbox):
+def test_request_password_reset_unregistered_email(live_server, mailoutbox):
     """
     Submitting a password reset request for a non-existent email should
     do nothing.
@@ -18,7 +18,7 @@ def test_password_reset_unregistered_email(live_server, mailoutbox):
     assert len(mailoutbox) == 0
 
 
-def test_password_reset_verified_email(live_server, mailoutbox):
+def test_request_password_reset_verified_email(live_server, mailoutbox):
     """
     Submitting a password reset request with a verified email should
     send a new password reset token to the provided address.
@@ -39,3 +39,24 @@ def test_password_reset_verified_email(live_server, mailoutbox):
 
     assert msg.to == [email.address]
     assert reset.token in msg.body
+
+
+def test_reset_password_valid_token(live_server):
+    """
+    A user with a valid password reset token should be able to reset
+    their password.
+    """
+    user = get_user_model().objects.create_user(name="Test User")
+    email = EmailAddress.objects.create(address="test@example.com", user=user)
+    reset = PasswordReset.objects.create(email=email)
+
+    new_password = "MySup3rSecurePassword"
+    data = {"password": new_password, "token": reset.token}
+    url = f"{live_server}/accounts/password-resets/"
+    response = requests.post(url, data)
+
+    user.refresh_from_db()
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == {}
+    assert user.check_password(new_password)

--- a/ultimanager/functional_tests/accounts/passwords/test_password_resets.py
+++ b/ultimanager/functional_tests/accounts/passwords/test_password_resets.py
@@ -1,0 +1,41 @@
+import requests
+from django.contrib.auth import get_user_model
+from email_auth.models import EmailAddress, PasswordReset
+from rest_framework import status
+
+
+def test_password_reset_unregistered_email(live_server, mailoutbox):
+    """
+    Submitting a password reset request for a non-existent email should
+    do nothing.
+    """
+    data = {"email": "does-not-exist@example.com"}
+    url = f"{live_server}/accounts/password-reset-requests/"
+    response = requests.post(url, data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == data
+    assert len(mailoutbox) == 0
+
+
+def test_password_reset_verified_email(live_server, mailoutbox):
+    """
+    Submitting a password reset request with a verified email should
+    send a new password reset token to the provided address.
+    """
+    user = get_user_model().objects.create_user(name="Test User")
+    email = EmailAddress.objects.create(
+        address="test@example.com", is_verified=True, user=user
+    )
+    data = {"email": email.address}
+    url = f"{live_server}/accounts/password-reset-requests/"
+    response = requests.post(url, data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == data
+
+    msg = mailoutbox[0]
+    reset = PasswordReset.objects.get()
+
+    assert msg.to == [email.address]
+    assert reset.token in msg.body


### PR DESCRIPTION
Added endpoints (`/accounts/password-reset-requests/` and `/accounts/password-resets/`) that allow users to reset their password using any of their verified email addresses.

Closes #26 